### PR TITLE
renames the interface Parser to avoid conflicts with other pugins

### DIFF
--- a/includes/parsers/docx.php
+++ b/includes/parsers/docx.php
@@ -1,7 +1,7 @@
 <?php
 include_once 'parser.php';
 
-class DocxParser implements Parser {
+class DocxParser implements ParserWPfileSearch {
 
     public static function parse($filename) {
         $striped_content = '';

--- a/includes/parsers/odt.php
+++ b/includes/parsers/odt.php
@@ -1,7 +1,7 @@
 <?php
 include_once 'parser.php';
 
-class OdtParser implements Parser {
+class OdtParser implements ParserWPfileSearch {
 
     public static function parse($filename) {
         $striped_content = '';

--- a/includes/parsers/parser.php
+++ b/includes/parsers/parser.php
@@ -1,5 +1,5 @@
 <?php
 
-interface Parser {
+interface ParserWPfileSearch {
 	public static function parse($filename);
 }

--- a/includes/parsers/pdf.php
+++ b/includes/parsers/pdf.php
@@ -1,6 +1,6 @@
 <?php
 
-class PdfParser implements Parser {
+class PdfParser implements ParserWPfileSearch {
 	public static function parse($filename) {
         if (!$filename || !file_exists($filename))
             return false;


### PR DESCRIPTION
Did not play nice with plugin “Ninja Forms”, this fixes the problem by renaming "Parser" to "ParserWPfileSearch"
Cannot redeclare class Parser in /homepages/28/d89642000/htdocs/clickandbuilds/EirePittsburghPrivateSite/wp-content/plugins/wp-file-search/includes/parsers/parser.php on line 3